### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,9 @@ build: vendor
 src_deps=$(shell find pkg cmd -type f -name "*.go")
 $(OUT_DIR)/%/adapter: vendor $(src_deps)
 	CGO_ENABLED=0 GOARCH=$* go build -tags netgo -o $(OUT_DIR)/$(ARCH)/adapter github.com/kairosinc/custom-metrics-prometheus-adapter/cmd/adapter
-	
+
 docker-build: vendor
-	docker run -it \
+	docker run --rm \
 		-v $(shell pwd)/bin/:/build \
 		-v $(shell pwd):/go/src/github.com/kairosinc/custom-metrics-prometheus-adapter \
 		-e GOARCH=$(ARCH) $(GOIMAGE) \


### PR DESCRIPTION
This PR fixes the Jenkins build that was breaking while trying to build the go binary using the `golang` docker image:
```
+ GIT_BRANCH=master GIT_COMMIT=909eace9bee773678393741ca0eec20f76a1c5d6 make build
docker run -it -v /home/jenkins-agent/workspace/s-prometheus-adapter_master-D4DFGZH3673HUPLKJYMU4HNHCGQIEL3WSXZORQC2N3XV2BKX6DOA:/go/src/github.com/kairosinc/custom-metrics-prometheus-adapter -w /go/src/github.com/kairosinc/custom-metrics-prometheus-adapter golang:1.10 /bin/bash -c "\
	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
	&& dep ensure -vendor-only"
cannot enable tty mode on non tty input
Makefile:69: recipe for target 'vendor' failed
make: *** [vendor] Error 1
```
Because this `Makefile` is being ran by the build agent, a TTY is not available for the docker container to attach to.

Removing the `-it` removes the requirement of an available TTY and forwards all messages to `stout` and `stderr`.

The `--rm ` flag only adds the hability for the build agent to cleanup after itself (removing the golang container once the build finishes.